### PR TITLE
Fix for issue (#318) and (#319)

### DIFF
--- a/src/renderer/App/components/Board/style.scss
+++ b/src/renderer/App/components/Board/style.scss
@@ -58,3 +58,7 @@
 .Board__isnt-maximized {
   min-height: 1000vh;
 }
+
+.Browser__draggable-container {
+  min-width: 300px;
+}


### PR DESCRIPTION
Closes #318
Closes #319

Fixes issue (#318) where the fav star becomes dettached from the browser on browser resize and (#319) where the browser can no longer resize from the right-hand-side.

Pixels are necessary for fix to work consistently, rather than relative units such vw.

300px was picked as it's round about the minimum you can resize before things break and it's a nice round number.

Perhaps not a permenant solution, but works very well and I think 300px is definetly a fair minimum, I can't see much use in a browser narrower than this.