### PR TITLE
Fixed board tab position on mac to be further left.

### DIFF
--- a/src/renderer/TitleBar/components/TopBar/style.scss
+++ b/src/renderer/TitleBar/components/TopBar/style.scss
@@ -11,8 +11,8 @@
 }
 
 .macTitleBar {
-  padding-left: 130px;
-  width: calc(100% - 130px) !important;
+  padding-left: 80px;
+  width: calc(100% - 80px) !important;
 }
 
 #TopBar__tabs-container {


### PR DESCRIPTION
There was too much whitespace between the native mac controls (close, max, min) and the boardName tabs. Reduced this a suitable amount.