### PR TITLE
Fix/ui-boardname-empty

### DIFF
--- a/src/renderer/TitleBar/components/TopBar/TopBar.tsx
+++ b/src/renderer/TitleBar/components/TopBar/TopBar.tsx
@@ -361,7 +361,7 @@ export const TopBar: React.FC = () => {
                     id="TopBar__tab-renaming"
                   />
                 ) : (
-                  `${t.label} (${t.windowsCount || '?'})`
+                  `${t.label} (${t.windowsCount || '0'})`
                 )}
               </div>
 


### PR DESCRIPTION
changed boardname tab to display 0 instead of ? when empty.